### PR TITLE
Ajax update of index page entries on search, sort_link, pagination, and additional flash messages

### DIFF
--- a/app/assets/javascripts/articles.coffee
+++ b/app/assets/javascripts/articles.coffee
@@ -1,3 +1,5 @@
 # Place all the behaviors and hooks related to the matching controller here.
 # All this logic will automatically be available in application.js.
 # You can use CoffeeScript in this file: http://coffeescript.org/
+$ ->
+  $('.pagination a').attr('data-remote', 'true')

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -6,7 +6,8 @@ class ArticlesController < ApplicationController
     @articles = @q.result(distinct: true).paginate(:page => params[:page], :per_page => 4)
     respond_to do |format|
       format.html {render :index}
-      format.json {render json: @articles}
+      format.js {}
+      format.json {render json: {:articles => @articles}}
     end
   end
 
@@ -25,6 +26,7 @@ class ArticlesController < ApplicationController
   def create
     @article = Article.new(article_params)
     if @article.save
+      flash[:success] = "article created successfully."
       redirect_to @article
     else
       render 'new'
@@ -35,6 +37,7 @@ class ArticlesController < ApplicationController
     @article = Article.friendly.find(params[:id])
 
     if @article.update(article_params)
+      flash[:success] = "article updated successfully."
       redirect_to @article
     else
       render 'edit'
@@ -44,12 +47,8 @@ class ArticlesController < ApplicationController
   def destroy
     @article = Article.friendly.find(params[:id])
     @article.destroy
-
+    flash[:success] = "article destroyed successfully."
     redirect_to articles_path
-  end
-
-  def search
-    index
   end
 
   private

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -4,6 +4,10 @@ class ArticlesController < ApplicationController
   def index
     @q = Article.ransack(params[:q])
     @articles = @q.result(distinct: true)
+    respond_to do |format|
+      format.html {render :index}
+      format.json {render json: @articles}
+    end
   end
 
   def show
@@ -46,7 +50,6 @@ class ArticlesController < ApplicationController
 
   def search
     index
-    render :index
   end
 
   private

--- a/app/views/articles/_list.html.haml
+++ b/app/views/articles/_list.html.haml
@@ -1,11 +1,11 @@
 %table.my-table
   %tr
     %th
-    %th= sort_link @q, :title
+    %th= sort_link @q, :title, {}, { :remote => true }
     %th Text
-    %th= sort_link @q, :created_at, default_order: :desc
-    %th= sort_link @q, :updated_at, default_order: :desc
-    %th{:colspan => 3} Action
+    %th= sort_link @q, :created_at, { default_order: :desc }, { :remote => true }
+    %th= sort_link @q, :updated_at, { default_order: :desc }, { :remote => true }
+    %th{ :colspan => 3 } Action
 
   - articles.each do |article|
     %tr

--- a/app/views/articles/index.html.haml
+++ b/app/views/articles/index.html.haml
@@ -1,8 +1,8 @@
 %h1 Articles List:
 .row
   .col-sm-8.col-md-4.col-lg-3
-    = search_form_for @q, :url => search_articles_url, html: {method: :get},
-     :class => "form", :role => :search do |f|
+    = search_form_for @q, :url => articles_url,
+     :class => "form", remote: true, :role => :search do |f|
       .form-group
         .input-group
           = f.search_field :title_cont, :class => "form-control", :placeholder => "search title"
@@ -12,4 +12,4 @@
 
 = link_to 'New article', new_article_path
 
-= render "list", :articles => @articles
+#results= render "list", :articles => @articles

--- a/app/views/articles/index.js.haml
+++ b/app/views/articles/index.js.haml
@@ -1,0 +1,3 @@
+:plain
+  $('#results').html("#{ j (render partial: 'list', locals: {articles: @articles}) }");
+  $('.pagination a').attr('data-remote', 'true');

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -39,9 +39,6 @@ Rails.application.routes.draw do
 
   devise_for :users
   resources :articles do
-    collection do
-      match 'search' => 'articles#search', via: [:get, :post], as: :search
-    end
     resources :comments, :only => [:create, :destroy]
   end
   resources :tags, :only => [:index, :show]


### PR DESCRIPTION
**What this PR does:**
- index page article entries updation via Ajax, rather than updating the whole table.
- Ajax update on pagination
- Ajax update on sort_link
- Flash messages on destroy, create and update article (in addition to the ones added earlier for login and create errors)
